### PR TITLE
pylint: add more good variable names

### DIFF
--- a/python/pylintrc
+++ b/python/pylintrc
@@ -382,10 +382,13 @@ function-naming-style=snake_case
 good-names=i,
            j,
            k,
+           f,  # for files
            e,  # for exceptions
            ex,
            Run,
-           _
+           _,
+           __,
+           ui
 
 # Good variable names regexes, separated by a comma. If names match any regex,
 # they will always be accepted


### PR DESCRIPTION
Добавил некоторые допустимые имена переменных в pylintrc, чтобы было меньше ругани на адекватный код:

 `f` - для объектов файлов, например:
 ```python3
with open("filename.txt", encoding="utf-8") as f:
  ...
```

`_` - для аргументов и переменных при распаковке кортежей, которые не используются в функции, а также для функции перевода `gettext`

`__` - для неиспользуемых аргументов, если задействован `gettext`

`ui` - просто хорошее название из двух букв, которое может означать объект пользовательского интерфейса (UI)