### PR TITLE
lintian: temporarily disable dist name check

### DIFF
--- a/lintian/profiles/wirenboard/main.profile
+++ b/lintian/profiles/wirenboard/main.profile
@@ -3,3 +3,6 @@ Extends: debian/main
 
 Tags: syntax-error-in-debian-changelog
 Severity: serious
+
+Tags: bad-distribution-in-changes-file
+Severity: normal


### PR DESCRIPTION
In WB CI, lintian from stretch is still used for checks. Since it doesn't know about bullseye, lintian checks fail on new builds.

This patch (temporarily) disables dist name check (makes it warning instead of error).