### PR TITLE
pyproject.toml: update target-version to py39

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 110
-target-version = ['py35']
+target-version = ['py39']
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Debian Bullseye ships [python 3.9](https://packages.debian.org/bullseye/python3).
Having `target-version=py35`, pylint warns:
```sh
W2601: F-strings are not supported by all versions included in the py-version setting (using-f-string-in-unsupported-version)
```
Since f-strings were introduced in Python version 3.6.