### PR TITLE
pyproject.toml: downgrade target-version to py38

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 110
-target-version = ['py39']
+target-version = ['py38']
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
black 20.8b1 (from wbdev) doesn't support py39 yet:
`Error: Invalid value for '-t' / '--target-version': invalid choice: py39. (choose from py27, py33, py34, py35, py36, py37, py38)`