### PR TITLE
clang-format-subdirs.sh: avoid shell's wildcard expansion

### DIFF
--- a/clang-format-subdirs.sh
+++ b/clang-format-subdirs.sh
@@ -9,7 +9,7 @@ fi
 FAIL=0
 
 for dir in "$@"; do
-    find ${dir} -iname *.h -o -iname *.cpp | xargs clang-format -n --Werror -i || FAIL=1
+    find ${dir} -iname '*.h' -o -iname '*.cpp' | xargs clang-format -n --Werror -i || FAIL=1
 done
 
 exit $FAIL


### PR DESCRIPTION
How to reproduce:
```sh
$ cd wb-mqtt-serial/src
$ clang-format-subdirs.sh .
find: paths must precede expression: `bin_utils.h'
find: possible unquoted pattern after predicate `-iname'?
error: cannot use -i when reading from stdin.
```