### PR TITLE
Fix find-python-files

### DIFF
--- a/ci/find-python-files
+++ b/ci/find-python-files
@@ -3,7 +3,7 @@
 files=`find . -name "*.py"; for file in \`find . -type f ! -name "*.*"\`; do mime=\`file -b --mime-type "$file"\`; if [ "$mime" == 'text/x-python' ] || [ "$mime" == 'text/x-script.python' ]; then echo "$file"; fi; done `
 
 if [ "$WB_PYTHON_FILES_EXCLUDE" ]; then
-    for file in `echo "$files" | grep -qv "$WB_PYTHON_FILES_EXCLUDE"` ; do
+    for file in `echo "$files" | grep -v "$WB_PYTHON_FILES_EXCLUDE"` ; do
         echo $file;
     done
 else


### PR DESCRIPTION
C `-q` список всегда будет пустой.
Связано с https://github.com/wirenboard/codestyle/pull/31