### PR TITLE
Add coverage config file

### DIFF
--- a/python/.coveragerc
+++ b/python/.coveragerc
@@ -1,2 +1,5 @@
 [run]
 omit = /usr/lib/*
+; By default, the data file is located at /<<PKGBUILDDIR>>/.pybuild/cpython3_3.9_wb-nm-helper/build/.
+; Because of that sbuild includes this file in deb package. To avoid this, put the file directly into the /<<PKGBUILDDIR>>
+data_file = ../../../../.coverage 

--- a/python/.coveragerc
+++ b/python/.coveragerc
@@ -2,4 +2,4 @@
 omit = /usr/lib/*
 ; By default, the data file is located at /<<PKGBUILDDIR>>/.pybuild/cpython3_3.9_wb-nm-helper/build/.
 ; Because of that sbuild includes this file in deb package. To avoid this, put the file directly into the /<<PKGBUILDDIR>>
-data_file = ../../../../.coverage 
+data_file = ../../../.coverage 

--- a/python/.coveragerc
+++ b/python/.coveragerc
@@ -1,2 +1,5 @@
 [run]
 omit = /usr/lib
+
+[report]
+fail_under = 90

--- a/python/.coveragerc
+++ b/python/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = /usr/lib

--- a/python/.coveragerc
+++ b/python/.coveragerc
@@ -1,5 +1,2 @@
 [run]
-omit = /usr/lib
-
-[report]
-fail_under = 90
+omit = /usr/lib/*


### PR DESCRIPTION
Добавила конфиг, так как опции запуска pytest-cov не полностью покрывают потребности. 
Что написано в конфиге:
При оценке покрытия не оцениваются библиотеки из usr/lib (они автоматически включаются в отчет так как выполняются во время тестирования). В отчет покрытия попадают только сами тесты и сорцы (то есть какой % кода тестов выполнился и % кода сорцов)
Еще добавила перемещение файла данных покрытия в директорию сборки, потому что sbuild иначе начинает складывать его в деб-пакет