### PR TITLE
Add coverage guide

### DIFF
--- a/python.ru.md
+++ b/python.ru.md
@@ -362,7 +362,7 @@ $ pytest --cov --cov-config=./.coveragerc --cov-report=term --cov-branch --cov-f
 
 #### Внутри venv
 
-1. Настроить venv [по инструкции для codestyle-проверок](###-Установка-codestyle-тулзов-(один-раз-для-проекта)). В venv должен установиться пакет pytest-cov.
+1. Настроить venv [по инструкции для codestyle-проверок](#установка-codestyle-тулзов-один-раз-для-проекта). В venv должен установиться пакет pytest-cov.
 2. Скачать из [codestyle-репозитория](https://github.com/wirenboard/codestyle/tree/master/python) файл `.coveragerc` и положить в корень проекта.
 3. Запустить
 ```console

--- a/python.ru.md
+++ b/python.ru.md
@@ -390,10 +390,12 @@ $ wbdev ndeb
 ### Настройка VSCode
 
 #### Для запуска тестов из VSCode:
-1. Установите плагин для Python и настройте запуск тестов через pytest
-2. Откройте настройки workspace: нажмите комбинацию `Ctrl-Shift-P`, в поиске введите `settings json`,
+
+1. Скачайте из [codestyle-репозитория](https://github.com/wirenboard/codestyle/tree/master/python) файл `.coveragerc` и положите в корень проекта.
+2. Установите плагин для Python и настройте запуск тестов через pytest
+3. Откройте настройки workspace: нажмите комбинацию `Ctrl-Shift-P`, в поиске введите `settings json`,
    выбираем `Preferences: Open Workspace Settings (JSON)`
-3. К массиву опций запуска добавляем:
+4. К массиву опций запуска добавляем:
 ```
 "--cov","--cov-config",".coveragerc","--cov-report","term","--cov-branch","--cov-fail-under","<limit>"
 ```

--- a/python.ru.md
+++ b/python.ru.md
@@ -342,6 +342,77 @@ $ deactivate
 }
 ```
 
+Code coverage
+-------------
+
+Для оценки покрытия тестов используется плагин pytest `coverage`. Оценка показывает процент выполнившихся строк кода и веток условий относительно общего объема файлов, использованных в процессе тестирования.
+
+### Запуск
+
+В зависимости от того, как вы запускаете тесты, нужно использовать разные сценарии.
+**Минимально допустимое значение покрытия для прохождения тестов указывается в аргументе `--cov-fail-under`** 
+
+#### Внутри devcontainer
+
+1. Скачать из [codestyle-репозитория](https://github.com/wirenboard/codestyle/tree/master/python) файл `.coveragerc` и положить в корень проекта.
+2. Запустить
+```console
+$ pytest --cov --cov-config=./.coveragerc --cov-report=term --cov-branch --cov-fail-under=<limit>
+```
+
+#### Внутри venv
+
+1. Настроить venv [по инструкции для codestyle-проверок](###-Установка-codestyle-тулзов-(один-раз-для-проекта)). В venv должен установиться пакет pytest-cov.
+2. Скачать из [codestyle-репозитория](https://github.com/wirenboard/codestyle/tree/master/python) файл `.coveragerc` и положить в корень проекта.
+3. Запустить
+```console
+$ pytest --cov --cov-config=./.coveragerc --cov-report=term --cov-branch --cov-fail-under=<limit>
+```
+
+#### Сборка wbdev
+
+Работает только для `wbdev ndeb` и `wbdev cdeb`
+1. Скачать из [codestyle-репозитория](https://github.com/wirenboard/codestyle/tree/master/python) файл `.coveragerc` и положить в корень проекта.
+2. Запустить
+```console
+$ export WBDEV_PYBUILD_TEST_ARGS="--cov --cov-config=../../../.coveragerc --cov-report=term --cov-branch --cov-fail-under=<limit>"
+$ wbdev ndeb
+```
+
+### Отчеты
+
+Для сборки внутри devcontainer и внутри venv есть возможность сгенерировать html отчет (для варианта wbdev сложные аргументы запуска, поэтому не приводим его). Для включения генерации нужно добавить опцию запуска
+```console
+--cov-report=html
+```
+В папке проекта создастся папка htmlcov. Чтобы посмотреть отчет, откройте файл index.html в браузере.
+
+### Настройка VSCode
+
+#### Для запуска тестов из VSCode:
+1. Установите плагин для Python и настройте запуск тестов через pytest
+2. Откройте настройки workspace: нажмите комбинацию `Ctrl-Shift-P`, в поиске введите `settings json`,
+   выбираем `Preferences: Open Workspace Settings (JSON)`
+3. К массиву опций запуска добавляем:
+```
+"--cov","--cov-config","./.coveragerc","--cov-report","term","--cov-branch","--cov-fail-under","<limit>"
+```
+Должны получиться примерно такие настройки:
+```json
+{
+    "python.testing.pytestArgs": [
+        "tests","--cov","--cov-config","./.coveragerc","--cov-report","term","--cov-branch","--cov-fail-under","<limit>"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}
+```
+
+#### Для просмотра отчета в исходных файлах:
+1. Установите плагин [Coverage Gutters](https://github.com/ryanluker/vscode-coverage-gutters)
+2. К опциям запуска добавьте `"--cov-report","xml"`
+3. Проведите тестирование
+3. Откройте файл, покрытие которого хотите посмотреть. В статус-баре VSCode найдите надпись `Watch` и нажмите ее для включения подсветки.
 
 
 Ещё гайдлайны

--- a/python.ru.md
+++ b/python.ru.md
@@ -357,7 +357,7 @@ Code coverage
 1. Скачать из [codestyle-репозитория](https://github.com/wirenboard/codestyle/tree/master/python) файл `.coveragerc` и положить в корень проекта.
 2. Запустить
 ```console
-$ pytest --cov --cov-config=./.coveragerc --cov-report=term --cov-branch --cov-fail-under=<limit>
+$ pytest --cov --cov-config=.coveragerc --cov-report=term --cov-branch --cov-fail-under=<limit>
 ```
 
 #### Внутри venv
@@ -366,7 +366,7 @@ $ pytest --cov --cov-config=./.coveragerc --cov-report=term --cov-branch --cov-f
 2. Скачать из [codestyle-репозитория](https://github.com/wirenboard/codestyle/tree/master/python) файл `.coveragerc` и положить в корень проекта.
 3. Запустить
 ```console
-$ pytest --cov --cov-config=./.coveragerc --cov-report=term --cov-branch --cov-fail-under=<limit>
+$ pytest --cov --cov-config=.coveragerc --cov-report=term --cov-branch --cov-fail-under=<limit>
 ```
 
 #### Сборка wbdev
@@ -395,13 +395,13 @@ $ wbdev ndeb
    выбираем `Preferences: Open Workspace Settings (JSON)`
 3. К массиву опций запуска добавляем:
 ```
-"--cov","--cov-config","./.coveragerc","--cov-report","term","--cov-branch","--cov-fail-under","<limit>"
+"--cov","--cov-config",".coveragerc","--cov-report","term","--cov-branch","--cov-fail-under","<limit>"
 ```
 Должны получиться примерно такие настройки:
 ```json
 {
     "python.testing.pytestArgs": [
-        "tests","--cov","--cov-config","./.coveragerc","--cov-report","term","--cov-branch","--cov-fail-under","<limit>"
+        "tests","--cov","--cov-config",".coveragerc","--cov-report","term","--cov-branch","--cov-fail-under","<limit>"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true

--- a/python/.coveragerc
+++ b/python/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-omit = /usr/lib/*
+omit = /usr/lib/* /root/*
 ; By default, the data file is located at /<<PKGBUILDDIR>>/.pybuild/cpython3_3.9_wb-nm-helper/build/.
 ; Because of that sbuild includes this file in deb package. To avoid this, put the file directly into the /<<PKGBUILDDIR>>
 data_file = ../../../.coverage 

--- a/python/.coveragerc
+++ b/python/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-omit = /usr/lib/* /root/*
+omit = /usr/lib/*, /root/*
 ; By default, the data file is located at /<<PKGBUILDDIR>>/.pybuild/cpython3_3.9_wb-nm-helper/build/.
 ; Because of that sbuild includes this file in deb package. To avoid this, put the file directly into the /<<PKGBUILDDIR>>
 data_file = ../../../.coverage 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,4 @@
 black==24.2.0
 isort==5.13.2
 pylint==3.1.0
+pytest-cov==2.10.1


### PR DESCRIPTION
Добавила как пользоваться coverage во всех доступных комбинациях
Не стала приводить как сделать отчет через запуск wbdev ndeb. Потому что опции запуска будут страшные (надо прокидывать аргументы для sbuild) и потому что это вряд ли это кому то будет надо, обычно сборку через wbdev запускают только проверить что оно собирается. А сделать отчет есть и более простые способы
Добавила /root/ в игнор для coverage потому что при запуске из vscode он начинает включать скодовские скрипты, при сборке на CI не повлияет