### PR TITLE
python: adopt PEP440

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 def get_version():
     with open("debian/changelog", "r", encoding="utf-8") as f:
-        return f.readline().split()[1][1:-1]
+        return f.readline().split()[1][1:-1].split("~")[0]
 
 
 setup(


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
В [новых версиях setuptools](https://github.com/pypa/setuptools/blob/main/NEWS.rst) (актуально для debian 13) нарушение [PEP 440](https://peps.python.org/pep-0440/) приводит к ошибке, а не к ворнингу как было ранее. У нас же в случае сборки веток к версии добавляется суффикс, например `2.2.6~exp~feature+trixie~1~g9e85f23`, что не есть валидная версия согласно PEP 440.

___________________________________
**Что поменялось для пользователей:**
Ничего.

___________________________________
**Как проверял/а:**
Сборка wb-common с таким фиксом на deb 13.