### PR TITLE
Change coverage data file path

### DIFF
--- a/python/.coveragerc
+++ b/python/.coveragerc
@@ -1,5 +1,5 @@
 [run]
 omit = /usr/lib/*, /root/*
 ; By default, the data file is located at /<<PKGBUILDDIR>>/.pybuild/cpython3_3.9_wb-nm-helper/build/.
-; Because of that sbuild includes this file in deb package. To avoid this, put the file directly into the /<<PKGBUILDDIR>>
-data_file = ../../../.coverage 
+; Because of that sbuild includes this file in deb package. To avoid this, put the file directly into the /<<BUILDDIR>>
+data_file = ../../../../.coverage 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Нужно перекладывать файл с покрытием на уровень выше, в BUILDDIR. В BUILDDIR складываются и другие артефаrты сборки, дебки и архив с html. Этот файлик раньше не был особо нужен и никто не заметил что он перекладывается немного не туда.
Сделать это через env vars у меня не получилось. В конфиге можно указывать переменные, но sbuild не выдает свои настройки через переменные окружения, позволяет только задавать их в конфиг-файле. Поэтому пока оставляем относительные пути :(
___________________________________
**Что поменялось для пользователей:**

Ничего
___________________________________
**Как проверял/а:**
 Запускала локально сборку в wbdev - попадает куда надо
```
+------------------------------------------------------------------------------+
| Post Build Commands                                                          |
+------------------------------------------------------------------------------+


schroot -d / -c bullseye-amd64-sbuild-9cfa6061-004d-4629-a2ec-81539388f4b4 --run-session -q -u root -p -- sh -c 'ls -a /<<BUILDDIR>>/ && find / -name .coverage'
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------

.
..
.coverage
htmlcov
htmlcov.tar.gz
python3-wb-nm-helper_1.35.0_all.deb
resolver-rwjsHG
wb-nm-helper-1.35.0
wb-nm-helper_1.35.0.dsc
wb-nm-helper_1.35.0.tar.gz
wb-nm-helper_1.35.0_all.buildinfo
wb-nm-helper_1.35.0_all.changes
wb-nm-helper_1.35.0_all.deb
/<<BUILDDIR>>/.coverage
```

