### PR TITLE
Add lintian trixie profile

### DIFF
--- a/lintian/profiles/wirenboard/trixie.profile
+++ b/lintian/profiles/wirenboard/trixie.profile
@@ -1,0 +1,5 @@
+Profile: wirenboard/trixie
+Extends: debian/main
+Disable-Tags:
+ bad-distribution-in-changes-file
+ unreleased-changes


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Для сборки на trixie.
В свежем lintian формат немного поломали, Severity больше не поддерживается:
`Unknown fields in section 2 of profile wirenboard/trixie: Severity at /usr/share/lintian/bin/../lib/Lintian/Profile.pm line 704.`
Поэтому пока отключил эти теги через Disable-Tags, вместо изменения Severity.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
локально

