### PR TITLE
Fix find-python-files

### DIFF
--- a/ci/find-python-files
+++ b/ci/find-python-files
@@ -4,7 +4,7 @@ python_files=()
 
 while IFS= read -r file; do
     python_files+=("$file")
-done < <(find . -name "*.py")
+done < <(find . -type d -name .git -prune -o -type f -name "*.py" -print)
 
 while IFS= read -r file; do
     mime=$(file -b --mime-type "$file")


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
В ts-ng назвали гит ветку с окончанием на .py, в итоге find-python-files нашел это как питоний файл внутри .git/, в результате сборка сломалась:
```sh
python -m black, 24.2.0 (compiled: no)
...
error: cannot format .git/refs/remotes/origin/feature/ft-25/fix-TABLE_NAMES_MAPPING-in-config.py: Cannot parse: 1:1:
```
___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
локально

