### PR TITLE
Add devcontainer-cli: headless DevContainers for CI and AI agents

### DIFF
--- a/devcontainer-cli
+++ b/devcontainer-cli
@@ -1,0 +1,3 @@
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PYTHONPATH="$SCRIPT_DIR" exec python3 -m devcontainer_cli "$@"

--- a/devcontainer_cli/README.md
+++ b/devcontainer_cli/README.md
@@ -6,7 +6,7 @@ VS Code DevContainers without VS Code. Runs the same `devcontainer.json`, `tasks
 
 ```bash
 cd ~/work/board/wb-mqtt-serial
-../codestyle/devcontainer-cli up --language cpp
+../codestyle/devcontainer-cli --language cpp up
 ```
 
 This creates a Docker container, starts it, and runs `postCreateCommand` (installs dev dependencies).
@@ -17,10 +17,10 @@ This creates a Docker container, starts it, and runs `postCreateCommand` (instal
 
 ```bash
 # Create and start container (first time runs postCreateCommand)
-../codestyle/devcontainer-cli up --language cpp
+../codestyle/devcontainer-cli --language cpp up
 
 # Rebuild from scratch
-../codestyle/devcontainer-cli up --language cpp --rebuild
+../codestyle/devcontainer-cli --language cpp up --rebuild
 
 # Stop container (keeps state)
 ../codestyle/devcontainer-cli stop

--- a/devcontainer_cli/README.md
+++ b/devcontainer_cli/README.md
@@ -1,0 +1,150 @@
+# devcontainer-cli
+
+VS Code DevContainers without VS Code. Runs the same `devcontainer.json`, `tasks.json`, and `launch.json` configs from the codestyle repo via CLI.
+
+## Quick Start
+
+```bash
+cd ~/work/board/wb-mqtt-serial
+../codestyle/devcontainer-cli up --language cpp
+```
+
+This creates a Docker container, starts it, and runs `postCreateCommand` (installs dev dependencies).
+
+## Commands
+
+### Container Lifecycle
+
+```bash
+# Create and start container (first time runs postCreateCommand)
+../codestyle/devcontainer-cli up --language cpp
+
+# Rebuild from scratch
+../codestyle/devcontainer-cli up --language cpp --rebuild
+
+# Stop container (keeps state)
+../codestyle/devcontainer-cli stop
+
+# Start stopped container
+../codestyle/devcontainer-cli start
+
+# Stop and remove container
+../codestyle/devcontainer-cli down
+
+# Show container state
+../codestyle/devcontainer-cli status
+```
+
+### Saving & Loading Containers
+
+After `up` runs `postCreateCommand` (which can take several minutes), you can snapshot the container to a file and restore it later — skipping the slow setup entirely.
+
+```bash
+# Save the prepared container to a tar.gz file
+../codestyle/devcontainer-cli save
+# Creates cpp-devenv.tar.gz (default name based on language)
+
+# Save with a custom filename
+../codestyle/devcontainer-cli save my-snapshot.tar.gz
+
+# Create a new container from the saved file (fast, no postCreateCommand)
+../codestyle/devcontainer-cli down
+../codestyle/devcontainer-cli up --image cpp-devenv.tar.gz
+```
+
+`--image` accepts both tar.gz files and Docker image tags. When given a file, it loads the image automatically.
+
+This is useful for sharing pre-built environments with teammates or moving them between machines.
+
+### Run Commands in Container
+
+```bash
+# Run arbitrary command
+../codestyle/devcontainer-cli exec ls -la
+
+# Run tests via qemu
+../codestyle/devcontainer-cli exec 'cd test && qemu-arm-static -L /srv/chroot/sbuild-bullseye-cross wb-homa-test'
+```
+
+### Tasks (from tasks.json)
+
+```bash
+# List all available tasks
+../codestyle/devcontainer-cli tasks list
+
+# Build for armhf
+../codestyle/devcontainer-cli tasks run "[armhf] Build"
+
+# Build for arm64
+../codestyle/devcontainer-cli tasks run "[arm64] Build"
+
+# Debug build
+../codestyle/devcontainer-cli tasks run "[armhf] Debug build"
+
+# Run all tests
+../codestyle/devcontainer-cli tasks run "[armhf] Run all tests"
+
+# Build and copy to controller (BINARY_NAME from Makefile, prompts for CONTROLLER_IP)
+../codestyle/devcontainer-cli tasks run "[armhf] Build and copy to remote target"
+
+# Same, with CONTROLLER_IP pre-set
+../codestyle/devcontainer-cli \
+  --var CONTROLLER_IP=192.168.1.100 \
+  tasks run "[armhf] Build and copy to remote target"
+```
+
+### Launch/Debug Configs (from launch.json)
+
+```bash
+# List available debug configurations
+../codestyle/devcontainer-cli launch list
+
+# Remote debug (BINARY_NAME from Makefile, only need CONTROLLER_IP)
+../codestyle/devcontainer-cli \
+  --var CONTROLLER_IP=192.168.1.100 \
+  launch run "[armhf] Remote debug"
+
+# Debug tests locally via qemu (all variables auto-detected from Makefile)
+../codestyle/devcontainer-cli launch run "[armhf] Debug tests"
+```
+
+## Variables
+
+Tasks and launch configs use placeholder variables (shown as `<ИМЯ ПРОЕКТА>` etc. in VS Code configs). Resolved from these sources (highest priority first):
+
+1. `--var KEY=VALUE` flags
+2. `.devcontainer-cli.json` in project root
+3. **Makefile auto-extraction** (parses `SERIAL_BIN`, `TEST_BIN`, `TEST_DIR`)
+4. Interactive prompt (if still unresolved)
+
+For wb-mqtt-serial, the Makefile contains `SERIAL_BIN = wb-mqtt-serial`, `TEST_BIN = wb-homa-test`, `TEST_DIR = test`, so `BINARY_NAME`, `TEST_BINARY_NAME`, and `TEST_BINARY_DIR` are set automatically — no `--var` flags needed.
+
+| Variable | Description | Auto-detected from Makefile |
+|----------|-------------|-----------------------------|
+| `PROJECT_NAME` | Project name | Always (directory name) |
+| `BINARY_NAME` | Binary to build/deploy | `SERIAL_BIN`, `BIN_NAME`, `BIN`, `BINARY` |
+| `TEST_BINARY_NAME` | Test binary name | `TEST_BIN` |
+| `TEST_BINARY_DIR` | Test binary directory | `TEST_DIR` |
+| `CONTROLLER_IP` | Target controller IP | No (must be set manually) |
+| `TEST_FILTER` | gtest filter pattern | No (must be set manually) |
+
+Example `.devcontainer-cli.json` (only needed for variables that can't be auto-detected):
+
+```json
+{
+  "CONTROLLER_IP": "192.168.1.100"
+}
+```
+
+## Global Options
+
+```
+--project-dir DIR         Project directory (default: current directory)
+--codestyle-dir DIR       Path to codestyle repo (default: auto-detected)
+--language cpp|go|python  Language config (default: auto-detect from devcontainer.json)
+--var KEY=VALUE           Set a variable (repeatable)
+```
+
+## Language Auto-Detection
+
+If the project has `.devcontainer/devcontainer.json` with a `postCreateCommand` referencing `cpp/`, `go/`, or `python/`, the language is detected automatically. Otherwise, use `--language`.

--- a/devcontainer_cli/__main__.py
+++ b/devcontainer_cli/__main__.py
@@ -1,0 +1,358 @@
+"""CLI entry point for devcontainer-cli."""
+
+import argparse
+import os
+import sys
+
+from .config import build_config, ProjectConfig
+from .container import (
+    container_name,
+    container_state,
+    create_container,
+    exec_in_container,
+    load_container_image,
+    remove_container,
+    run_post_create,
+    save_container,
+    start_container,
+    stop_container,
+)
+from .runner import list_launches, list_tasks, run_launch, run_task
+
+# File extensions that indicate a tar.gz image file
+_IMAGE_FILE_EXTENSIONS = (".tar.gz", ".tgz", ".tar")
+
+
+# ANSI colors
+def _color(code: int, text: str) -> str:
+    if not sys.stdout.isatty():
+        return text
+    return f"\033[{code}m{text}\033[0m"
+
+
+def green(text: str) -> str:
+    return _color(32, text)
+
+
+def yellow(text: str) -> str:
+    return _color(33, text)
+
+
+def red(text: str) -> str:
+    return _color(31, text)
+
+
+def bold(text: str) -> str:
+    return _color(1, text)
+
+
+def cyan(text: str) -> str:
+    return _color(36, text)
+
+
+def _build_config_from_args(args: argparse.Namespace) -> ProjectConfig:
+    """Build ProjectConfig from parsed CLI arguments."""
+    project_dir = os.path.abspath(args.project_dir)
+    codestyle_dir = os.path.abspath(args.codestyle_dir)
+
+    cli_vars: dict[str, str] = {}
+    if args.var:
+        for v in args.var:
+            if "=" not in v:
+                print(f"Error: --var must be KEY=VALUE, got: {v}", file=sys.stderr)
+                sys.exit(1)
+            key, value = v.split("=", 1)
+            cli_vars[key] = value
+
+    return build_config(
+        project_dir=project_dir,
+        codestyle_dir=codestyle_dir,
+        language=args.language,
+        cli_vars=cli_vars,
+    )
+
+
+def cmd_up(args: argparse.Namespace) -> None:
+    config = _build_config_from_args(args)
+    if args.image:
+        image = args.image
+        # If it looks like a file path, load it first
+        if any(image.endswith(ext) for ext in _IMAGE_FILE_EXTENSIONS) or os.path.isfile(image):
+            if not os.path.exists(image):
+                print(red(f"Image file not found: {image}"), file=sys.stderr)
+                sys.exit(1)
+            print(f"Loading image from {bold(image)}...")
+            tag = load_container_image(image)
+            if not tag:
+                print(red("Failed to determine image tag from loaded file."), file=sys.stderr)
+                sys.exit(1)
+            print(green(f"  Loaded image: {tag}"))
+            image = tag
+        config.devcontainer.image = image
+    name = container_name(config)
+    state = container_state(name)
+
+    if state == "running" and not args.rebuild:
+        print(green(f"Container {name} is already running."))
+        return
+
+    if args.rebuild and state != "missing":
+        print(yellow(f"Rebuilding: removing existing container {name}..."))
+        if state == "running":
+            stop_container(name)
+        remove_container(name)
+        state = "missing"
+
+    if state == "missing":
+        print(f"Creating container {bold(name)}...")
+        create_container(config)
+        print(green("  Container created."))
+        state = "stopped"
+
+    if state == "stopped":
+        print(f"Starting container {bold(name)}...")
+        start_container(name)
+        print(green("  Container started."))
+
+    run_post_create(config, name)
+    print(green("Ready."))
+
+
+def cmd_down(args: argparse.Namespace) -> None:
+    config = _build_config_from_args(args)
+    name = container_name(config)
+    state = container_state(name)
+
+    if state == "missing":
+        print(yellow("No container to remove."))
+        return
+
+    if state == "running":
+        print(f"Stopping container {bold(name)}...")
+        stop_container(name)
+
+    print(f"Removing container {bold(name)}...")
+    remove_container(name)
+    print(green("Done."))
+
+
+def cmd_stop(args: argparse.Namespace) -> None:
+    config = _build_config_from_args(args)
+    name = container_name(config)
+    state = container_state(name)
+
+    if state != "running":
+        print(yellow(f"Container {name} is not running (state: {state})."))
+        return
+
+    print(f"Stopping container {bold(name)}...")
+    stop_container(name)
+    print(green("Stopped."))
+
+
+def cmd_start(args: argparse.Namespace) -> None:
+    config = _build_config_from_args(args)
+    name = container_name(config)
+    state = container_state(name)
+
+    if state == "running":
+        print(green(f"Container {name} is already running."))
+        return
+    if state == "missing":
+        print(red("No container exists. Run 'up' first."))
+        sys.exit(1)
+
+    print(f"Starting container {bold(name)}...")
+    start_container(name)
+    print(green("Started."))
+
+
+def cmd_status(args: argparse.Namespace) -> None:
+    config = _build_config_from_args(args)
+    name = container_name(config)
+    state = container_state(name)
+
+    color_fn = {"running": green, "stopped": yellow, "missing": red}.get(state, str)
+    print(f"Container: {bold(name)}")
+    print(f"State:     {color_fn(state)}")
+    print(f"Project:   {config.project_dir}")
+    print(f"Language:  {config.language}")
+
+
+def cmd_exec(args: argparse.Namespace) -> None:
+    config = _build_config_from_args(args)
+    name = container_name(config)
+    state = container_state(name)
+
+    if state != "running":
+        print(red(f"Container is not running (state: {state}). Run 'up' first."), file=sys.stderr)
+        sys.exit(1)
+
+    cmd_parts = [a for a in args.exec_command if a != "--"]
+    command = " ".join(cmd_parts) if cmd_parts else "bash"
+    exit_code = exec_in_container(
+        name, command, workdir=config.container_workspace, interactive=True
+    )
+    sys.exit(exit_code)
+
+
+def cmd_tasks(args: argparse.Namespace) -> None:
+    config = _build_config_from_args(args)
+
+    if args.tasks_command == "list":
+        list_tasks(config)
+    elif args.tasks_command == "run":
+        name = container_name(config)
+        state = container_state(name)
+        if state != "running":
+            print(
+                red(f"Container is not running (state: {state}). Run 'up' first."),
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        exit_code = run_task(config, name, args.label)
+        sys.exit(exit_code)
+    else:
+        print("Usage: devcontainer-cli tasks {list|run LABEL}", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_save(args: argparse.Namespace) -> None:
+    config = _build_config_from_args(args)
+    name = container_name(config)
+    state = container_state(name)
+
+    if state == "missing":
+        print(red("No container exists. Run 'up' first."), file=sys.stderr)
+        sys.exit(1)
+
+    image_tag = f"wbdev-snapshot-{config.language}:latest"
+    output_path = args.file or f"{config.language}-devenv.tar.gz"
+
+    print(f"Saving container {bold(name)} as {bold(image_tag)}...")
+    save_container(name, image_tag, output_path)
+    print(green("Done."))
+
+
+def cmd_launch(args: argparse.Namespace) -> None:
+    config = _build_config_from_args(args)
+
+    if args.launch_command == "list":
+        list_launches(config)
+    elif args.launch_command == "run":
+        name = container_name(config)
+        state = container_state(name)
+        if state != "running":
+            print(
+                red(f"Container is not running (state: {state}). Run 'up' first."),
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        exit_code = run_launch(config, name, args.name)
+        sys.exit(exit_code)
+    else:
+        print("Usage: devcontainer-cli launch {list|run NAME}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> None:
+    # Determine default codestyle dir: script location's parent
+    script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    default_codestyle = script_dir
+
+    parser = argparse.ArgumentParser(
+        prog="devcontainer-cli",
+        description="VS Code DevContainers without VS Code",
+    )
+    parser.add_argument(
+        "--project-dir",
+        default=os.getcwd(),
+        help="Project directory (default: current directory)",
+    )
+    parser.add_argument(
+        "--codestyle-dir",
+        default=default_codestyle,
+        help=f"Path to codestyle repo (default: {default_codestyle})",
+    )
+    parser.add_argument(
+        "--language",
+        choices=["cpp", "go", "python"],
+        default=None,
+        help="Language config to use (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--var",
+        action="append",
+        metavar="KEY=VALUE",
+        help="Set a placeholder variable (repeatable)",
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    # up
+    up_parser = subparsers.add_parser("up", help="Create and start container")
+    up_parser.add_argument("--rebuild", action="store_true", help="Rebuild container from scratch")
+    up_parser.add_argument("--image", default=None, help="Use a saved image (tar.gz file or docker image tag)")
+
+    # down
+    subparsers.add_parser("down", help="Stop and remove container")
+
+    # stop
+    subparsers.add_parser("stop", help="Stop container")
+
+    # start
+    subparsers.add_parser("start", help="Start existing stopped container")
+
+    # status
+    subparsers.add_parser("status", help="Show container state")
+
+    # save
+    save_parser = subparsers.add_parser("save", help="Save container state to tar.gz")
+    save_parser.add_argument("file", nargs="?", default=None, help="Output file (default: <language>-devenv.tar.gz)")
+
+    # exec
+    exec_parser = subparsers.add_parser("exec", help="Run command inside container")
+    exec_parser.add_argument("exec_command", nargs=argparse.REMAINDER, help="Command to run")
+
+    # tasks
+    tasks_parser = subparsers.add_parser("tasks", help="Manage tasks from tasks.json")
+    tasks_sub = tasks_parser.add_subparsers(dest="tasks_command")
+    tasks_sub.add_parser("list", help="List all tasks")
+    tasks_run = tasks_sub.add_parser("run", help="Run a task by label")
+    tasks_run.add_argument("label", help="Task label to run")
+
+    # launch
+    launch_parser = subparsers.add_parser("launch", help="Manage launch configurations")
+    launch_sub = launch_parser.add_subparsers(dest="launch_command")
+    launch_sub.add_parser("list", help="List launch configurations")
+    launch_run = launch_sub.add_parser("run", help="Run a launch configuration")
+    launch_run.add_argument("name", help="Launch configuration name")
+
+    args = parser.parse_args()
+
+    if args.command is None:
+        parser.print_help()
+        sys.exit(1)
+
+    handlers = {
+        "up": cmd_up,
+        "down": cmd_down,
+        "stop": cmd_stop,
+        "start": cmd_start,
+        "status": cmd_status,
+        "save": cmd_save,
+        "exec": cmd_exec,
+        "tasks": cmd_tasks,
+        "launch": cmd_launch,
+    }
+
+    handler = handlers.get(args.command)
+    if handler:
+        handler(args)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/devcontainer_cli/config.py
+++ b/devcontainer_cli/config.py
@@ -1,0 +1,379 @@
+"""Configuration parsing for devcontainer-cli.
+
+Parses devcontainer.json, tasks.json, launch.json with JSONC support
+and VS Code variable resolution.
+"""
+
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+# Russian placeholder → ASCII key mapping
+PLACEHOLDER_MAP = {
+    "ИМЯ ПРОЕКТА": "PROJECT_NAME",
+    "ИМЯ БИНАРНИКА": "BINARY_NAME",
+    "IP КОНТРОЛЛЕРА": "CONTROLLER_IP",
+    "ПАПКА С БИНАРНИКОМ ТЕСТОВ": "TEST_BINARY_DIR",
+    "ИМЯ БИНАРНИКА ТЕСТОВ": "TEST_BINARY_NAME",
+    "ИМЯ ТЕСТА": "TEST_FILTER",
+}
+
+# Reverse mapping for display
+ASCII_TO_RUSSIAN = {v: k for k, v in PLACEHOLDER_MAP.items()}
+
+PLACEHOLDER_DESCRIPTIONS = {
+    "PROJECT_NAME": "Project name (basename of project dir)",
+    "BINARY_NAME": "Binary name to build/deploy",
+    "CONTROLLER_IP": "IP address of the target controller",
+    "TEST_BINARY_DIR": "Directory containing test binary",
+    "TEST_BINARY_NAME": "Test binary name",
+    "TEST_FILTER": "Test filter (e.g. gtest_filter pattern)",
+}
+
+
+def load_jsonc(path: str) -> dict:
+    """Load a JSONC file (JSON with comments and trailing commas)."""
+    text = Path(path).read_text(encoding="utf-8")
+    # Remove single-line comments (// ...) but not inside strings
+    result = []
+    in_string = False
+    escape = False
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if escape:
+            result.append(ch)
+            escape = False
+            i += 1
+            continue
+        if ch == "\\" and in_string:
+            result.append(ch)
+            escape = True
+            i += 1
+            continue
+        if ch == '"' and not escape:
+            in_string = not in_string
+            result.append(ch)
+            i += 1
+            continue
+        if not in_string and ch == "/" and i + 1 < len(text):
+            if text[i + 1] == "/":
+                # Skip single-line comment until end of line
+                while i < len(text) and text[i] != "\n":
+                    i += 1
+                continue
+            if text[i + 1] == "*":
+                # Skip block comment until */
+                i += 2
+                while i + 1 < len(text) and not (text[i] == "*" and text[i + 1] == "/"):
+                    i += 1
+                i += 2  # skip closing */
+                continue
+        result.append(ch)
+        i += 1
+    text = "".join(result)
+    # Remove trailing commas before } or ]
+    text = re.sub(r",\s*([}\]])", r"\1", text)
+    return json.loads(text)
+
+
+@dataclass
+class DevcontainerConfig:
+    image: str = ""
+    run_args: list[str] = field(default_factory=list)
+    mounts: list[dict[str, str]] = field(default_factory=list)
+    post_create_command: str = ""
+    container_env: dict[str, str] = field(default_factory=dict)
+
+
+def parse_mount_spec(mount_string: str, variables: dict[str, str]) -> dict[str, str]:
+    """Parse a mount specification string into a dict.
+
+    Input: "source=${localWorkspaceFolder}/../codestyle,target=/workspaces/codestyle,type=bind"
+    Output: {"source": "/resolved/path", "target": "/workspaces/codestyle", "type": "bind"}
+    """
+    mount = {}
+    for part in mount_string.split(","):
+        if "=" not in part:
+            continue
+        key, value = part.split("=", 1)
+        value = resolve_variables(value, variables)
+        # Normalize source paths (resolve .. components)
+        if key == "source":
+            value = str(Path(value).resolve())
+        mount[key] = value
+    return mount
+
+
+def parse_devcontainer(path: str, variables: dict[str, str]) -> DevcontainerConfig:
+    """Parse a devcontainer.json file."""
+    data = load_jsonc(path)
+    config = DevcontainerConfig()
+    config.image = data.get("image", "")
+    config.run_args = data.get("runArgs", [])
+
+    raw_mounts = data.get("mounts", [])
+    for m in raw_mounts:
+        if isinstance(m, str):
+            config.mounts.append(parse_mount_spec(m, variables))
+        elif isinstance(m, dict):
+            resolved = {}
+            for k, v in m.items():
+                resolved[k] = resolve_variables(str(v), variables)
+            config.mounts.append(resolved)
+
+    config.post_create_command = data.get("postCreateCommand", "")
+    raw_env = data.get("containerEnv", {})
+    for k, v in raw_env.items():
+        config.container_env[k] = resolve_variables(v, variables)
+
+    return config
+
+
+def resolve_variables(text: str, context: dict[str, str]) -> str:
+    """Resolve VS Code variables and Russian placeholders in text.
+
+    Handles:
+      ${localWorkspaceFolder}  → context["localWorkspaceFolder"]
+      ${workspaceFolder}       → context["workspaceFolder"]
+      ${workspaceRoot}         → context["workspaceFolder"]
+      ${localEnv:VARNAME}      → os.environ.get(VARNAME, "")
+      <RUSSIAN PLACEHOLDER>    → context value via PLACEHOLDER_MAP
+    """
+    if not isinstance(text, str):
+        return text
+
+    # Resolve ${localEnv:VARNAME}
+    def replace_local_env(m: re.Match[str]) -> str:
+        var_name = m.group(1)
+        return os.environ.get(var_name, "")
+
+    text = re.sub(r"\$\{localEnv:([^}]+)\}", replace_local_env, text)
+
+    # Resolve ${variable} patterns
+    def replace_var(m: re.Match[str]) -> str:
+        var_name = m.group(1)
+        if var_name == "workspaceRoot":
+            var_name = "workspaceFolder"
+        return context.get(var_name, m.group(0))
+
+    text = re.sub(r"\$\{([^}:]+)\}", replace_var, text)
+
+    # Resolve Russian placeholders: <ИМЯ ПРОЕКТА> → context value
+    for russian, ascii_key in PLACEHOLDER_MAP.items():
+        placeholder = f"<{russian}>"
+        if placeholder in text and ascii_key in context:
+            text = text.replace(placeholder, context[ascii_key])
+
+    return text
+
+
+def detect_language(project_dir: str) -> str | None:
+    """Auto-detect language from project's devcontainer.json."""
+    devcontainer_path = os.path.join(project_dir, ".devcontainer", "devcontainer.json")
+    if not os.path.exists(devcontainer_path):
+        return None
+    try:
+        data = load_jsonc(devcontainer_path)
+    except (json.JSONDecodeError, OSError):
+        return None
+    post_create = data.get("postCreateCommand", "")
+    if "cpp/" in post_create:
+        return "cpp"
+    if "go/" in post_create:
+        return "go"
+    if "python/" in post_create:
+        return "python"
+    return None
+
+
+def extract_vars_from_makefile(project_dir: str) -> dict[str, str]:
+    """Try to extract BINARY_NAME, TEST_BINARY_NAME, TEST_BINARY_DIR from Makefile."""
+    makefile_path = os.path.join(project_dir, "Makefile")
+    if not os.path.exists(makefile_path):
+        return {}
+
+    try:
+        text = Path(makefile_path).read_text(encoding="utf-8")
+    except OSError:
+        return {}
+
+    result: dict[str, str] = {}
+
+    # Patterns for the main binary name.
+    # Match lines like: SERIAL_BIN = wb-mqtt-serial
+    #                   BIN = my-daemon
+    #                   BINARY_NAME = foo
+    # Only match simple assignments (no $(shell ...) or $(...) references).
+    for pattern in [
+        r"^(?:SERIAL_BIN|BIN_NAME|BIN|BINARY)\s*[:?]?=\s*(\S+)",
+    ]:
+        m = re.search(pattern, text, re.MULTILINE)
+        if m:
+            value = m.group(1)
+            if "$" not in value:
+                result.setdefault("BINARY_NAME", value)
+                break
+
+    # Test binary name: TEST_BIN = wb-homa-test
+    for pattern in [
+        r"^TEST_BIN\s*[:?]?=\s*(\S+)",
+    ]:
+        m = re.search(pattern, text, re.MULTILINE)
+        if m:
+            value = m.group(1)
+            if "$" not in value:
+                result.setdefault("TEST_BINARY_NAME", value)
+                break
+
+    # Test directory: TEST_DIR = test
+    for pattern in [
+        r"^TEST_DIR\s*[:?]?=\s*(\S+)",
+    ]:
+        m = re.search(pattern, text, re.MULTILINE)
+        if m:
+            value = m.group(1)
+            if "$" not in value:
+                result.setdefault("TEST_BINARY_DIR", value)
+                break
+
+    return result
+
+
+def load_user_vars(project_dir: str) -> dict[str, str]:
+    """Load user variables from .devcontainer-cli.json in project dir."""
+    vars_path = os.path.join(project_dir, ".devcontainer-cli.json")
+    if not os.path.exists(vars_path):
+        return {}
+    try:
+        with open(vars_path, encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            print(f"Warning: {vars_path} should contain a JSON object", file=sys.stderr)
+            return {}
+        return data
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Warning: failed to load {vars_path}: {e}", file=sys.stderr)
+        return {}
+
+
+def find_unresolved_placeholders(text: str) -> list[str]:
+    """Find Russian placeholders that haven't been resolved yet."""
+    found = []
+    for russian in PLACEHOLDER_MAP:
+        if f"<{russian}>" in text:
+            ascii_key = PLACEHOLDER_MAP[russian]
+            if ascii_key not in found:
+                found.append(ascii_key)
+    return found
+
+
+def prompt_for_variables(needed: list[str], user_vars: dict[str, str]) -> dict[str, str]:
+    """Interactively prompt for unresolved variables."""
+    for var in needed:
+        if var in user_vars:
+            continue
+        russian = ASCII_TO_RUSSIAN.get(var, var)
+        desc = PLACEHOLDER_DESCRIPTIONS.get(var, var)
+        if var == "PROJECT_NAME":
+            # Don't prompt for PROJECT_NAME, it's auto-set
+            continue
+        try:
+            value = input(f"  {var} ({desc}) [<{russian}>]: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            value = ""
+        if value:
+            user_vars[var] = value
+    return user_vars
+
+
+@dataclass
+class ProjectConfig:
+    project_dir: str = ""
+    codestyle_dir: str = ""
+    language: str = ""
+    devcontainer: DevcontainerConfig = field(default_factory=DevcontainerConfig)
+    user_vars: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def project_name(self) -> str:
+        return os.path.basename(self.project_dir)
+
+    @property
+    def container_workspace(self) -> str:
+        return f"/workspaces/{self.project_name}"
+
+    def vscode_dir(self) -> str:
+        """Path to the language-specific .vscode directory in codestyle."""
+        return os.path.join(self.codestyle_dir, self.language, "vscode", ".vscode")
+
+    def make_variable_context(self) -> dict[str, str]:
+        """Build the full variable context for resolution."""
+        ctx = {
+            "localWorkspaceFolder": self.project_dir,
+            "workspaceFolder": self.container_workspace,
+            "PROJECT_NAME": self.project_name,
+        }
+        ctx.update(self.user_vars)
+        return ctx
+
+
+def build_config(
+    project_dir: str,
+    codestyle_dir: str,
+    language: str | None = None,
+    cli_vars: dict[str, str] | None = None,
+) -> ProjectConfig:
+    """Build a complete ProjectConfig from arguments."""
+    project_dir = os.path.abspath(project_dir)
+    codestyle_dir = os.path.abspath(codestyle_dir)
+
+    if not os.path.isdir(project_dir):
+        print(f"Error: project directory not found: {project_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    if not os.path.isdir(codestyle_dir):
+        print(f"Error: codestyle directory not found: {codestyle_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    if language is None:
+        language = detect_language(project_dir)
+        if language is None:
+            print(
+                "Error: cannot auto-detect language. Use --language cpp|go|python",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    devcontainer_path = os.path.join(
+        codestyle_dir, language, "vscode", ".devcontainer", "devcontainer.json"
+    )
+    if not os.path.exists(devcontainer_path):
+        print(f"Error: devcontainer.json not found: {devcontainer_path}", file=sys.stderr)
+        sys.exit(1)
+
+    # Merge variable sources: CLI vars > .devcontainer-cli.json > Makefile > defaults
+    makefile_vars = extract_vars_from_makefile(project_dir)
+    user_vars = makefile_vars
+    user_vars.update(load_user_vars(project_dir))
+    if cli_vars:
+        user_vars.update(cli_vars)
+    # Always set PROJECT_NAME
+    user_vars.setdefault("PROJECT_NAME", os.path.basename(project_dir))
+
+    config = ProjectConfig(
+        project_dir=project_dir,
+        codestyle_dir=codestyle_dir,
+        language=language,
+        user_vars=user_vars,
+    )
+
+    variables = config.make_variable_context()
+    config.devcontainer = parse_devcontainer(devcontainer_path, variables)
+
+    return config

--- a/devcontainer_cli/container.py
+++ b/devcontainer_cli/container.py
@@ -1,0 +1,275 @@
+"""Docker container lifecycle management for devcontainer-cli."""
+
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+
+from .config import ProjectConfig
+
+
+def _docker_cmd() -> str:
+    """Return docker command, preferring podman if available."""
+    if shutil.which("podman"):
+        return "podman"
+    return "docker"
+
+
+def container_name(config: ProjectConfig) -> str:
+    """Generate deterministic container name from project path.
+
+    Format: wbdev-{md5(abs_project_path)[:8]}-{basename}
+    """
+    abs_path = os.path.abspath(config.project_dir)
+    path_hash = hashlib.md5(abs_path.encode()).hexdigest()[:8]
+    basename = os.path.basename(abs_path)
+    return f"wbdev-{path_hash}-{basename}"
+
+
+def container_state(name: str) -> str:
+    """Get container state: 'missing', 'running', or 'stopped'."""
+    docker = _docker_cmd()
+    try:
+        result = subprocess.run(
+            [docker, "inspect", "--format", "{{.State.Running}}", name],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return "missing"
+        output = result.stdout.strip()
+        return "running" if output == "true" else "stopped"
+    except FileNotFoundError:
+        print("Error: docker/podman not found in PATH", file=sys.stderr)
+        sys.exit(1)
+
+
+def create_container(config: ProjectConfig) -> str:
+    """Create a new container from the devcontainer config. Returns container name."""
+    docker = _docker_cmd()
+    name = container_name(config)
+    dc = config.devcontainer
+
+    cmd = [docker, "create", "--name", name, "-w", config.container_workspace, "-it"]
+
+    # runArgs from devcontainer.json
+    cmd.extend(dc.run_args)
+
+    # Implicit project mount
+    cmd.extend(["-v", f"{config.project_dir}:{config.container_workspace}"])
+
+    # Explicit mounts from devcontainer.json
+    for mount in dc.mounts:
+        source = mount.get("source", "")
+        target = mount.get("target", "")
+        mount_type = mount.get("type", "bind")
+        if not source or not target:
+            continue
+        # Skip mounts with non-existent source directories
+        if mount_type == "bind" and not os.path.exists(source):
+            print(f"  Warning: skipping mount, source not found: {source}", file=sys.stderr)
+            continue
+        mount_str = f"type={mount_type},source={source},target={target}"
+        if mount.get("readonly"):
+            mount_str += ",readonly"
+        cmd.extend(["--mount", mount_str])
+
+    # Container environment variables
+    for key, value in dc.container_env.items():
+        cmd.extend(["-e", f"{key}={value}"])
+
+    # Override entrypoint to keep container alive
+    cmd.extend(["--entrypoint", "sleep"])
+    cmd.append(dc.image)
+    cmd.append("infinity")
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error creating container:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    return name
+
+
+def start_container(name: str) -> None:
+    """Start a stopped container."""
+    docker = _docker_cmd()
+    result = subprocess.run([docker, "start", name], capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error starting container:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+
+def stop_container(name: str) -> None:
+    """Stop a running container."""
+    docker = _docker_cmd()
+    result = subprocess.run([docker, "stop", name], capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error stopping container:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+
+def remove_container(name: str) -> None:
+    """Remove a container."""
+    docker = _docker_cmd()
+    result = subprocess.run([docker, "rm", "-f", name], capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error removing container:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+
+SENTINEL_PATH = "/var/.wbdev-post-create-done"
+
+
+def run_post_create(config: ProjectConfig, name: str) -> None:
+    """Run postCreateCommand if it hasn't been run yet."""
+    post_cmd = config.devcontainer.post_create_command
+    if not post_cmd:
+        return
+
+    docker = _docker_cmd()
+
+    # Check sentinel
+    check = subprocess.run(
+        [docker, "exec", name, "test", "-f", SENTINEL_PATH],
+        capture_output=True,
+    )
+    if check.returncode == 0:
+        return
+
+    print(f"  Running postCreateCommand: {post_cmd}")
+    result = subprocess.run(
+        [docker, "exec", "-w", config.container_workspace, name, "bash", "-c", post_cmd],
+    )
+    if result.returncode != 0:
+        print("Error: postCreateCommand failed", file=sys.stderr)
+        sys.exit(1)
+
+    # Create sentinel
+    subprocess.run(
+        [docker, "exec", name, "touch", SENTINEL_PATH],
+        capture_output=True,
+    )
+
+
+def exec_in_container(
+    name: str,
+    command: str,
+    workdir: str | None = None,
+    env: dict[str, str] | None = None,
+    interactive: bool = False,
+) -> int:
+    """Execute a command inside the container. Returns exit code."""
+    docker = _docker_cmd()
+    cmd = [docker, "exec"]
+
+    if interactive and sys.stdin.isatty():
+        cmd.extend(["-it"])
+
+    if workdir:
+        cmd.extend(["-w", workdir])
+
+    if env:
+        for key, value in env.items():
+            cmd.extend(["-e", f"{key}={value}"])
+
+    cmd.append(name)
+    cmd.extend(["bash", "-c", command])
+
+    result = subprocess.run(cmd)
+    return result.returncode
+
+
+def save_container(name: str, image_tag: str, output_path: str) -> None:
+    """Snapshot a container and export the image to a tar.gz file.
+
+    1. docker commit <name> <image_tag>
+    2. docker save <image_tag> | gzip > <output_path>
+    """
+    docker = _docker_cmd()
+
+    # Commit container to image
+    result = subprocess.run(
+        [docker, "commit", name, image_tag],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"Error committing container:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    # Save image to tar.gz
+    save_proc = subprocess.Popen(
+        [docker, "save", image_tag],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    with open(output_path, "wb") as f:
+        gzip_proc = subprocess.Popen(
+            ["gzip"],
+            stdin=save_proc.stdout,
+            stdout=f,
+            stderr=subprocess.PIPE,
+        )
+        if save_proc.stdout:
+            save_proc.stdout.close()
+        _, gzip_err = gzip_proc.communicate()
+        _, save_err = save_proc.communicate()
+
+    if save_proc.returncode != 0:
+        print(f"Error saving image:\n{save_err.decode()}", file=sys.stderr)
+        sys.exit(1)
+    if gzip_proc.returncode != 0:
+        print(f"Error compressing image:\n{gzip_err.decode()}", file=sys.stderr)
+        sys.exit(1)
+
+    size_mb = os.path.getsize(output_path) / (1024 * 1024)
+    print(f"  Saved {output_path} ({size_mb:.1f} MB)")
+
+
+def load_container_image(input_path: str) -> str:
+    """Import a container image from a tar.gz file. Returns the loaded image tag."""
+    docker = _docker_cmd()
+    result = subprocess.run(
+        [docker, "load", "-i", input_path],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"Error loading image:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse output like "Loaded image: wbdev-snapshot-cpp:latest"
+    for line in result.stdout.strip().splitlines():
+        if "Loaded image" in line:
+            tag = line.split(":", 1)[1].strip()
+            # Handle "Loaded image: tag" and "Loaded image ID: sha256:..."
+            return tag
+
+    print(f"Warning: could not parse loaded image tag from: {result.stdout}", file=sys.stderr)
+    return ""
+
+
+def exec_in_container_background(
+    name: str,
+    command: str,
+    workdir: str | None = None,
+    env: dict[str, str] | None = None,
+) -> tuple[int, str]:
+    """Run a command in the container in background (detached). Returns (exit_code, stderr)."""
+    docker = _docker_cmd()
+    cmd = [docker, "exec", "-d"]
+
+    if workdir:
+        cmd.extend(["-w", workdir])
+
+    if env:
+        for key, value in env.items():
+            cmd.extend(["-e", f"{key}={value}"])
+
+    cmd.append(name)
+    cmd.extend(["bash", "-c", command])
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result.returncode, result.stderr

--- a/devcontainer_cli/runner.py
+++ b/devcontainer_cli/runner.py
@@ -1,0 +1,396 @@
+"""Task and launch configuration execution for devcontainer-cli."""
+
+import os
+import shlex
+import sys
+
+from .config import (
+    ProjectConfig,
+    find_unresolved_placeholders,
+    load_jsonc,
+    prompt_for_variables,
+    resolve_variables,
+)
+from .container import exec_in_container, exec_in_container_background
+
+
+def _task_group_label(group: str | dict) -> str:
+    """Extract group kind from task group field."""
+    if isinstance(group, dict):
+        return group.get("kind", "")
+    return group
+
+
+def load_tasks(config: ProjectConfig) -> list[dict]:
+    """Load tasks from tasks.json, merging codestyle and project-local tasks."""
+    tasks: list[dict] = []
+    global_env: dict[str, str] = {}
+
+    # Load from codestyle language-specific tasks.json
+    codestyle_tasks_path = os.path.join(config.vscode_dir(), "tasks.json")
+    if os.path.exists(codestyle_tasks_path):
+        data = load_jsonc(codestyle_tasks_path)
+        # Extract global options.env (Go has this)
+        options = data.get("options", {})
+        global_env = options.get("env", {})
+        tasks.extend(data.get("tasks", []))
+
+    # Load from project-local tasks.json (project overrides codestyle)
+    project_tasks_path = os.path.join(config.project_dir, ".vscode", "tasks.json")
+    if os.path.exists(project_tasks_path):
+        data = load_jsonc(project_tasks_path)
+        options = data.get("options", {})
+        proj_env = options.get("env", {})
+        global_env.update(proj_env)
+        existing_labels = {t.get("label"): i for i, t in enumerate(tasks)}
+        for task in data.get("tasks", []):
+            label = task.get("label")
+            if label in existing_labels:
+                tasks[existing_labels[label]] = task
+            else:
+                tasks.append(task)
+
+    # Merge global env into each task
+    for task in tasks:
+        task_options = task.get("options", {})
+        task_env = task_options.get("env", {})
+        merged_env = dict(global_env)
+        merged_env.update(task_env)
+        if merged_env:
+            task.setdefault("options", {})["env"] = merged_env
+
+    return tasks
+
+
+def _find_task(tasks: list[dict], label: str) -> dict | None:
+    """Find a task by label."""
+    for t in tasks:
+        if t.get("label") == label:
+            return t
+    return None
+
+
+def resolve_task_order(tasks: list[dict], label: str) -> list[str]:
+    """DFS topological sort on dependsOn graph. Returns execution order."""
+    visited: set[str] = set()
+    in_stack: set[str] = set()
+    order: list[str] = []
+
+    def dfs(current_label: str) -> None:
+        if current_label in visited:
+            return
+        if current_label in in_stack:
+            print(f"Error: dependency cycle detected at task '{current_label}'", file=sys.stderr)
+            sys.exit(1)
+
+        task = _find_task(tasks, current_label)
+        if task is None:
+            print(f"Error: task '{current_label}' not found", file=sys.stderr)
+            sys.exit(1)
+
+        in_stack.add(current_label)
+
+        deps = task.get("dependsOn", [])
+        depends_order = task.get("dependsOrder", "parallel")
+
+        if depends_order == "sequence":
+            # Run dependencies in order as listed
+            for dep in deps:
+                dfs(dep)
+        else:
+            # Parallel order — still need to resolve all deps
+            for dep in deps:
+                dfs(dep)
+
+        in_stack.discard(current_label)
+        visited.add(current_label)
+        order.append(current_label)
+
+    dfs(label)
+    return order
+
+
+def _build_task_command(task: dict, config: ProjectConfig) -> str:
+    """Build the shell command for a task, resolving variables."""
+    ctx = config.make_variable_context()
+    command = task.get("command", "")
+    args = task.get("args", [])
+
+    command = resolve_variables(command, ctx)
+
+    if args:
+        resolved_args = [resolve_variables(str(a), ctx) for a in args]
+        command = command + " " + " ".join(resolved_args)
+
+    return command
+
+
+def _build_task_env(task: dict, config: ProjectConfig) -> dict[str, str]:
+    """Build environment variables for a task."""
+    ctx = config.make_variable_context()
+    env: dict[str, str] = {}
+    task_options = task.get("options", {})
+    task_env = task_options.get("env", {})
+    for k, v in task_env.items():
+        env[k] = resolve_variables(str(v), ctx)
+    return env
+
+
+def _build_task_cwd(task: dict, config: ProjectConfig) -> str | None:
+    """Build working directory for a task."""
+    ctx = config.make_variable_context()
+    task_options = task.get("options", {})
+    cwd = task_options.get("cwd")
+    if cwd:
+        return resolve_variables(cwd, ctx)
+    return None
+
+
+def run_task(config: ProjectConfig, container: str, label: str) -> int:
+    """Run a task by label, resolving dependencies first. Returns exit code."""
+    tasks = load_tasks(config)
+
+    # Check task exists
+    task = _find_task(tasks, label)
+    if task is None:
+        print(f"Error: task '{label}' not found", file=sys.stderr)
+        available = [t.get("label", "") for t in tasks]
+        print(f"Available tasks: {', '.join(available)}", file=sys.stderr)
+        return 1
+
+    # Resolve all variables needed for the full task chain
+    order = resolve_task_order(tasks, label)
+
+    # Check for unresolved placeholders and prompt if needed
+    ctx = config.make_variable_context()
+    all_commands = ""
+    for task_label in order:
+        t = _find_task(tasks, task_label)
+        if t:
+            all_commands += " " + t.get("command", "")
+            all_commands += " " + " ".join(str(a) for a in t.get("args", []))
+
+    needed = find_unresolved_placeholders(resolve_variables(all_commands, ctx))
+    if needed:
+        print("Some variables need to be set:")
+        config.user_vars = prompt_for_variables(needed, config.user_vars)
+
+    # Execute tasks in dependency order
+    for task_label in order:
+        t = _find_task(tasks, task_label)
+        if t is None:
+            continue
+
+        command = _build_task_command(t, config)
+        env = _build_task_env(t, config)
+        cwd = _build_task_cwd(t, config)
+        is_background = t.get("isBackground", False)
+
+        print(f"\n  Running task: {task_label}")
+        print(f"  Command: {command}")
+
+        if is_background:
+            workdir = cwd or config.container_workspace
+            exit_code, stderr = exec_in_container_background(
+                container, command, workdir=workdir, env=env
+            )
+            if exit_code != 0:
+                print(f"  Error starting background task: {stderr}", file=sys.stderr)
+                return exit_code
+            print("  Started in background.")
+        else:
+            workdir = cwd or config.container_workspace
+            exit_code = exec_in_container(
+                container, command, workdir=workdir, env=env, interactive=True
+            )
+            if exit_code != 0:
+                print(f"  Task '{task_label}' failed with exit code {exit_code}", file=sys.stderr)
+                return exit_code
+
+    return 0
+
+
+def list_tasks(config: ProjectConfig) -> None:
+    """Pretty-print all available tasks."""
+    tasks = load_tasks(config)
+    if not tasks:
+        print("No tasks found.")
+        return
+
+    print(f"Tasks ({len(tasks)}):\n")
+    for task in tasks:
+        label = task.get("label", "<unnamed>")
+        group = task.get("group", "")
+        group_str = _task_group_label(group)
+        deps = task.get("dependsOn", [])
+
+        line = f"  {label}"
+        if group_str:
+            line += f"  [{group_str}]"
+        if deps:
+            line += f"  (depends: {', '.join(deps)})"
+        if task.get("isBackground"):
+            line += "  [background]"
+        print(line)
+
+
+def load_launch_configs(config: ProjectConfig) -> list[dict]:
+    """Load launch configurations from launch.json."""
+    configs: list[dict] = []
+
+    # Load from codestyle language-specific launch.json
+    codestyle_launch_path = os.path.join(config.vscode_dir(), "launch.json")
+    if os.path.exists(codestyle_launch_path):
+        data = load_jsonc(codestyle_launch_path)
+        configs.extend(data.get("configurations", []))
+
+    # Load from project-local launch.json (project overrides codestyle)
+    project_launch_path = os.path.join(config.project_dir, ".vscode", "launch.json")
+    if os.path.exists(project_launch_path):
+        data = load_jsonc(project_launch_path)
+        existing_names = {c.get("name"): i for i, c in enumerate(configs)}
+        for lc in data.get("configurations", []):
+            name = lc.get("name")
+            if name in existing_names:
+                configs[existing_names[name]] = lc
+            else:
+                configs.append(lc)
+
+    return configs
+
+
+def _find_launch_config(configs: list[dict], name: str) -> dict | None:
+    """Find a launch config by name."""
+    for c in configs:
+        if c.get("name") == name:
+            return c
+    return None
+
+
+def run_launch(config: ProjectConfig, container: str, name: str) -> int:
+    """Run a launch/debug configuration. Returns exit code."""
+    launch_configs = load_launch_configs(config)
+    lc = _find_launch_config(launch_configs, name)
+    if lc is None:
+        print(f"Error: launch configuration '{name}' not found", file=sys.stderr)
+        available = [c.get("name", "") for c in launch_configs]
+        print(f"Available: {', '.join(available)}", file=sys.stderr)
+        return 1
+
+    ctx = config.make_variable_context()
+
+    # Check for unresolved placeholders
+    import json as json_mod
+
+    lc_text = json_mod.dumps(lc)
+    needed = find_unresolved_placeholders(resolve_variables(lc_text, ctx))
+    if needed:
+        print("Some variables need to be set:")
+        config.user_vars = prompt_for_variables(needed, config.user_vars)
+        ctx = config.make_variable_context()
+
+    # Run preLaunchTask if specified
+    pre_task = lc.get("preLaunchTask")
+    if pre_task:
+        pre_task = resolve_variables(pre_task, ctx)
+        print(f"Running preLaunchTask: {pre_task}")
+        exit_code = run_task(config, container, pre_task)
+        if exit_code != 0:
+            return exit_code
+
+    lc_type = lc.get("type", "")
+    mode = lc.get("mode", "")
+
+    if lc_type == "cppdbg":
+        return _run_cppdbg(config, container, lc, ctx)
+    elif lc_type == "go" and mode == "remote":
+        return _run_go_remote(config, container, lc, ctx)
+    else:
+        print(f"Unsupported launch type: {lc_type} (mode: {mode})", file=sys.stderr)
+        return 1
+
+
+def _run_cppdbg(
+    config: ProjectConfig, container: str, lc: dict, ctx: dict[str, str]
+) -> int:
+    """Run a C++ debug configuration using gdb."""
+    program = resolve_variables(lc.get("program", ""), ctx)
+    setup_commands = lc.get("setupCommands", [])
+    pipe_transport = lc.get("pipeTransport")
+    mi_debugger_addr = lc.get("miDebuggerServerAddress")
+
+    # Determine debugger path
+    linux_config = lc.get("linux", {})
+    debugger_path = linux_config.get("miDebuggerPath", "gdb-multiarch")
+
+    # Build GDB command
+    gdb_args = [debugger_path, "-q"]
+
+    # Add setup commands as -ex arguments
+    for cmd in setup_commands:
+        text = cmd.get("text", "")
+        if text:
+            text = resolve_variables(text, ctx)
+            gdb_args.extend(["-ex", text])
+
+    if pipe_transport:
+        # Remote debug via SSH pipe: connect local gdb to remote gdbserver
+        pipe_program = pipe_transport.get("pipeProgram", "/usr/bin/ssh")
+        pipe_args = pipe_transport.get("pipeArgs", [])
+
+        resolved_pipe_args = [resolve_variables(str(a), ctx) for a in pipe_args]
+        ssh_target = " ".join(resolved_pipe_args)
+        target_cmd = f"target remote | {pipe_program} {ssh_target} gdbserver - {program}"
+        gdb_args.extend(["-ex", target_cmd])
+        gdb_args.append(program)
+
+    elif mi_debugger_addr:
+        # Local QEMU debug
+        addr = resolve_variables(mi_debugger_addr, ctx)
+        gdb_args.extend(["-ex", f"target remote {addr}"])
+        gdb_args.append(program)
+
+    else:
+        gdb_args.append(program)
+
+    command = " ".join(shlex.quote(a) for a in gdb_args)
+    cwd = resolve_variables(lc.get("cwd", config.container_workspace), ctx)
+
+    print(f"  Starting debugger: {command}")
+    return exec_in_container(container, command, workdir=cwd, interactive=True)
+
+
+def _run_go_remote(
+    config: ProjectConfig, container: str, lc: dict, ctx: dict[str, str]
+) -> int:
+    """Run a Go remote debug configuration using dlv."""
+    host = resolve_variables(lc.get("host", ""), ctx)
+    port = lc.get("port", 4000)
+
+    command = f"dlv connect {host}:{port}"
+    print(f"  Starting debugger: {command}")
+    return exec_in_container(
+        container, command, workdir=config.container_workspace, interactive=True
+    )
+
+
+def list_launches(config: ProjectConfig) -> None:
+    """Pretty-print all launch configurations."""
+    launch_configs = load_launch_configs(config)
+    if not launch_configs:
+        print("No launch configurations found.")
+        return
+
+    print(f"Launch configurations ({len(launch_configs)}):\n")
+    for lc in launch_configs:
+        name = lc.get("name", "<unnamed>")
+        lc_type = lc.get("type", "")
+        mode = lc.get("mode", lc.get("request", ""))
+        pre_task = lc.get("preLaunchTask", "")
+
+        line = f"  {name}  [{lc_type}]"
+        if mode:
+            line += f"  ({mode})"
+        if pre_task:
+            line += f"  pre: {pre_task}"
+        print(line)


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

CLI-инструмент для запуска DevContainers без VS Code. Основная задача — дать AI-агентам (Claude Code и др.) возможность собирать наш софт в изолированном окружении, используя те же `devcontainer.json`, `tasks.json` и `launch.json` из codestyle.

Команды:
- `up` / `down` / `stop` / `start` / `status` — управление контейнером
- `exec` — выполнение команд внутри контейнера
- `tasks run` / `launch run` — запуск задач и debug-конфигураций из VS Code конфигов
- `save` — сохранение подготовленного контейнера в tar.gz (чтобы не ждать `postCreateCommand`)
- `up --image FILE` — создание контейнера из сохранённого образа (принимает и tar.gz файл, и docker image tag)

Переменные (`BINARY_NAME`, `TEST_BINARY_NAME` и т.д.) автоматически определяются из Makefile проекта.

___________________________________
**Что поменялось для пользователей:**

Новый инструмент `devcontainer-cli`. Существующий функционал не затронут.

___________________________________
**Как проверял/а:**

Вручную на wb-mqtt-serial:
```bash
cd ~/work/board/wb-mqtt-serial
../codestyle/devcontainer-cli up --language cpp
../codestyle/devcontainer-cli tasks run "[armhf] Build"
../codestyle/devcontainer-cli save
../codestyle/devcontainer-cli down
../codestyle/devcontainer-cli up --image cpp-devenv.tar.gz
../codestyle/devcontainer-cli tasks run "[armhf] Build"
```
