### PR TITLE
pylint: support for python 3.13

### DIFF
--- a/python/config/requirements.txt
+++ b/python/config/requirements.txt
@@ -1,4 +1,4 @@
 black==24.2.0
 isort==5.13.2
-pylint==3.1.0
+pylint==3.3.9
 pytest-cov==2.10.1


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
в trixie будет python 3.13, его поддержка в pylint добавлена в [3.3.0](https://github.com/pylint-dev/pylint/releases/tag/v3.3.0). В [3.3.3](https://github.com/pylint-dev/pylint/releases/tag/v3.3.3) исправлено https://github.com/pylint-dev/pylint/issues/10112, что у нас стреляло. Обновим сразу до 3.3.9, как последний релиз поддерживающий одновременно 3.9 и 3.13 питоны.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**


